### PR TITLE
feat!: implement pagination via PaginatedList

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"scripts": {
 		"test": "phpunit -c .config/phpunit.xml",
 		"check": "composer rector && composer ecs:fix && composer phpmd && composer phpstan",
-		"rector": "rector -c .config/rector.php",
+		"rector": "rector -c .config/rector.php --clear-cache",
 		"ecs": "ecs --config=.config/ecs.php",
 		"ecs:fix": "ecs --config=.config/ecs.php --fix",
 		"phpstan": "phpstan analyse src --level=8",

--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -9,6 +9,8 @@ use Koalati\Webflow\Api\Module\MembershipEndpoints;
 use Koalati\Webflow\Api\Module\MetaEndpoints;
 use Koalati\Webflow\Api\Module\SiteEndpoints;
 use Koalati\Webflow\Exception\WebflowClientException;
+use Koalati\Webflow\Model\WebflowModelInterface;
+use Koalati\Webflow\Util\PaginatedList;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -58,25 +60,53 @@ class Client
 
 	/**
 	 * @param null|array<string,mixed> $body
-	 * @return array<mixed,mixed>
+	 * @return array<string,mixed>
 	 */
 	protected function request(string $method, string $endpoint, ?array $body = null): array
 	{
 		$options = [];
 
 		if ($body !== null) {
-			$options['json'] = $body;
+			$bodyParam = $method === 'GET' ? 'query' : 'json';
+			$options[$bodyParam] = $body;
 		}
 
 		$response = $this->httpClient->request($method, $endpoint, $options);
 
 		try {
+			/** @var array<string,mixed> */
 			$responseData = $response->toArray();
 		} catch (ClientException $clientException) {
+			/** @var array<string,mixed> */
 			$responseData = $response->toArray(false);
 			throw new WebflowClientException($responseData['msg'] ?? $clientException->getMessage(), $clientException);
 		}
 
 		return $responseData;
+	}
+
+	/**
+	 * @template T of WebflowModelInterface
+	 * @param null|array<string,mixed> $body
+	 * @param class-string<T> $model
+	 * @return PaginatedList<T>
+	 */
+	protected function requestWithPagination(string $model, string $endpoint, ?array $body = null): PaginatedList
+	{
+		$responseData = $this->request('GET', $endpoint, $body);
+
+		$client = $this;
+		$paginatedList = new PaginatedList(
+			function (int $offset) use ($endpoint, $body, $client) {
+				$queryParams = $body;
+				$queryParams['offset'] = $offset;
+
+				return $client->request('GET', $endpoint, $queryParams);
+			},
+			$model,
+			$responseData
+		);
+
+		return $paginatedList;
 	}
 }

--- a/src/Api/Module/CmsEndpoints.php
+++ b/src/Api/Module/CmsEndpoints.php
@@ -9,6 +9,7 @@ use Koalati\Webflow\Exception\CollectionItemPublishingException;
 use Koalati\Webflow\Model\Cms\Collection;
 use Koalati\Webflow\Model\Cms\CollectionItem;
 use Koalati\Webflow\Model\Site\Site;
+use Koalati\Webflow\Util\PaginatedList;
 
 /**
  * Implementation of API calls for the "CMS" module (collections, items, etc.).
@@ -20,7 +21,7 @@ trait CmsEndpoints
 	/**
 	 * List of all collections in a given site.
 	 *
-	 * @return array<int,Collection>
+	 * @return array<int, Collection>
 	 */
 	public function listCollections(string|Site $siteId): array
 	{
@@ -47,20 +48,11 @@ trait CmsEndpoints
 	/**
 	 * Get all items for a collection
 	 *
-	 * @return array<int,CollectionItem>
+	 * @return PaginatedList<CollectionItem>
 	 */
-	public function listCollectionItems(string|Collection $collectionId): array
+	public function listCollectionItems(string|Collection $collectionId): PaginatedList
 	{
-		$response = $this->request('GET', "/collections/{$collectionId}/items");
-		$items = [];
-
-		foreach ($response['items'] as $itemData) {
-			$items[] = CollectionItem::createFromArray($itemData);
-		}
-
-		// @TODO: add pagination support - this currently only fetches the first page
-
-		return $items;
+		return $this->requestWithPagination(CollectionItem::class, "/collections/{$collectionId}/items");
 	}
 
 	/**
@@ -138,7 +130,7 @@ trait CmsEndpoints
 	/**
 	 * Remove or unpublish items in a collection.
 	 *
-	 * @param array<int,string|CollectionItem> $itemIds
+	 * @param array<int, (string | CollectionItem)> $itemIds
 	 * @param bool $keepAsDraft	When $keepAsDraft is set to `true`, the items will be unpublished and kept as drafts instead of being deleted.
 	 * @throws CollectionItemDeletionException
 	 */
@@ -171,7 +163,7 @@ trait CmsEndpoints
 	/**
 	 * Publish items in a Collection.
 	 *
-	 * @param array<int,string|CollectionItem> $itemIds
+	 * @param array<int, (string | CollectionItem)> $itemIds
 	 *
 	 * @throws CollectionItemPublishingException
 	 */

--- a/src/Api/Module/MembershipEndpoints.php
+++ b/src/Api/Module/MembershipEndpoints.php
@@ -9,6 +9,7 @@ use Koalati\Webflow\Exception\InvalidUserUpdateException;
 use Koalati\Webflow\Model\Membership\AccessGroup;
 use Koalati\Webflow\Model\Membership\User;
 use Koalati\Webflow\Model\Site\Site;
+use Koalati\Webflow\Util\PaginatedList;
 
 /**
  * Implementation of API calls for the "Membership" module (users, access groups).
@@ -20,20 +21,11 @@ trait MembershipEndpoints
 	/**
 	 * Get a list of users for a site
 	 *
-	 * @return array<int,User>
+	 * @return PaginatedList<User>
 	 */
-	public function listUsers(string|Site $siteId): array
+	public function listUsers(string|Site $siteId): PaginatedList
 	{
-		$response = $this->request('GET', "/sites/{$siteId}/users");
-		$users = [];
-
-		foreach ($response['users'] as $userData) {
-			$users[] = User::createFromArray($userData);
-		}
-
-		// @TODO: add pagination support - this currently only fetches the first page
-
-		return $users;
+		return $this->requestWithPagination(User::class, "/sites/{$siteId}/users");
 	}
 
 	/**
@@ -104,19 +96,10 @@ trait MembershipEndpoints
 	/**
 	 * Get a list of access groups for a site
 	 *
-	 * @return array<int,AccessGroup>
+	 * @return PaginatedList<AccessGroup>
 	 */
-	public function listAccessGroups(string|Site $siteId): array
+	public function listAccessGroups(string|Site $siteId): PaginatedList
 	{
-		$response = $this->request('GET', "/sites/{$siteId}/accessgroups");
-		$accessGroups = [];
-
-		foreach ($response['accessGroups'] as $accessGroupData) {
-			$accessGroups[] = AccessGroup::createFromArray($accessGroupData);
-		}
-
-		// @TODO: add pagination support - this currently only fetches the first page
-
-		return $accessGroups;
+		return $this->requestWithPagination(AccessGroup::class, "/sites/{$siteId}/accessgroups");
 	}
 }

--- a/src/Api/SiteClient.php
+++ b/src/Api/SiteClient.php
@@ -17,6 +17,7 @@ use Koalati\Webflow\Model\Meta\AuthorizedUser;
 use Koalati\Webflow\Model\Site\Domain;
 use Koalati\Webflow\Model\Site\Site;
 use Koalati\Webflow\Model\Site\Webhook;
+use Koalati\Webflow\Util\PaginatedList;
 
 /**
  * A Client that wraps `Koalati\Webflow\Api\Client` to simplify method calls
@@ -29,6 +30,7 @@ use Koalati\Webflow\Model\Site\Webhook;
  * @see https://developers.webflow.com/docs/api-overview
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SiteClient
 {
@@ -138,7 +140,7 @@ class SiteClient
 	/**
 	 * List of all collections in a given site.
 	 *
-	 * @return array<int,Collection>
+	 * @return array<int, Collection>
 	 */
 	public function listCollections(): array
 	{
@@ -156,9 +158,9 @@ class SiteClient
 	/**
 	 * Get all items for a collection
 	 *
-	 * @return array<int,CollectionItem>
+	 * @return PaginatedList<CollectionItem>
 	 */
-	public function listCollectionItems(Collection|string $collectionId): array
+	public function listCollectionItems(Collection|string $collectionId): PaginatedList
 	{
 		return $this->client->listCollectionItems($collectionId);
 	}
@@ -202,7 +204,7 @@ class SiteClient
 	/**
 	 * Remove or unpublish items in a collection.
 	 *
-	 * @param array<int,string|CollectionItem> $itemIds
+	 * @param array<int, (string | CollectionItem)> $itemIds
 	 * @param bool $keepAsDraft	When $keepAsDraft is set to `true`, the items will be unpublished and kept as drafts instead of being deleted.
 	 * @throws CollectionItemDeletionException
 	 */
@@ -214,7 +216,7 @@ class SiteClient
 	/**
 	 * Publish items in a Collection.
 	 *
-	 * @param array<int,string|CollectionItem> $itemIds
+	 * @param array<int, (string | CollectionItem)> $itemIds
 	 *
 	 * @throws CollectionItemPublishingException
 	 */
@@ -226,9 +228,9 @@ class SiteClient
 	/**
 	 * Get a list of users for a site
 	 *
-	 * @return array<int,User>
+	 * @return PaginatedList<User>
 	 */
-	public function listUsers(): array
+	public function listUsers(): PaginatedList
 	{
 		return $this->client->listUsers($this->siteId);
 	}
@@ -276,9 +278,9 @@ class SiteClient
 	/**
 	 * Get a list of access groups for a site
 	 *
-	 * @return array<int,AccessGroup>
+	 * @return PaginatedList<AccessGroup>
 	 */
-	public function listAccessGroups(): array
+	public function listAccessGroups(): PaginatedList
 	{
 		return $this->client->listAccessGroups($this->siteId);
 	}

--- a/src/Model/WebflowModelInterface.php
+++ b/src/Model/WebflowModelInterface.php
@@ -15,7 +15,7 @@ interface WebflowModelInterface
 	 * Creates an instance of the model from an array of data, such as an API
 	 * response's body.
 	 *
-	 * @param array<mixed,mixed> $data
+	 * @param array<string,mixed> $data
 	 */
 	public static function createFromArray(array $data): self;
 

--- a/src/Util/PaginatedList.php
+++ b/src/Util/PaginatedList.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koalati\Webflow\Util;
+
+use Iterator;
+use Koalati\Webflow\Model\WebflowModelInterface;
+
+/**
+ * A list of Webflow Models that simplifies interactions with the Webflow API
+ * pagination.
+ *
+ * The PaginatedList implements the Iterator interface, and can therefore be
+ * looped over like you would with an array. Data from subsequent pages will be
+ * loaded automatically as you need it.
+ *
+ * @template T of WebflowModelInterface
+ * @implements Iterator<int,T>
+ */
+class PaginatedList implements Iterator
+{
+	/**
+	 * Number of results per page.
+	 * `100` is Webflow's default and maximum value.
+	 */
+	public const LIMIT = 100;
+
+	private int $currentItemIndex = 0;
+
+	/**
+	 * Contains a cached version of the results for each page.
+	 *
+	 * @var array<int,array<int,T>>
+	 */
+	private array $pages = [];
+
+	/**
+	 * Total number of pages in the list.
+	 */
+	private int $total = 0;
+
+	/**
+	 * The key that contains the list of data in raw responses.
+	 */
+	private string $responseDataKey;
+
+	/**
+	 * @param callable(int $loadCallable): array<string,mixed> $loadCallable	Callable that takes an offset and returns the results of the list for that offset.
+	 * @param class-string<T> $model
+	 * @param array<string,mixed> $firstResponse
+	 */
+	public function __construct(
+		private $loadCallable,
+		public readonly string $model,
+		array $firstResponse,
+	) {
+		$this->total = $firstResponse['total'];
+		$this->responseDataKey = $this->guessDataKey($firstResponse);
+		$this->pages[0] = $this->hydrateResponse($firstResponse);
+	}
+
+	/**
+	 * Fetches the results for every page and returns them all as an array.
+	 *
+	 * @return array<int,T>
+	 */
+	public function fetchAll(): array
+	{
+		$originalIndex = $this->currentItemIndex;
+		$results = [];
+
+		$this->rewind();
+		foreach ($this as $result) {
+			$results[] = $result;
+		}
+		$this->currentItemIndex = $originalIndex;
+
+		return $results;
+	}
+
+	/**
+	 * @return T
+	 */
+	public function first(): mixed
+	{
+		return $this->pages[0][0];
+	}
+
+	public function current(): mixed
+	{
+		$indexWithinPage = max(1, ($this->currentItemIndex % self::LIMIT)) - 1;
+		$this->loadCurrentPage();
+
+		return $this->pages[$this->getCurrentPageIndex()][$indexWithinPage];
+	}
+
+	public function key(): mixed
+	{
+		return $this->currentItemIndex;
+	}
+
+	public function next(): void
+	{
+		$this->currentItemIndex++;
+	}
+
+	public function rewind(): void
+	{
+		$this->currentItemIndex = 0;
+	}
+
+	public function valid(): bool
+	{
+		return $this->currentItemIndex >= 0 && $this->currentItemIndex < $this->total;
+	}
+
+	private function loadCurrentPage(): void
+	{
+		if (! isset($this->pages[$this->getCurrentPageIndex()])) {
+			$offset = $this->getCurrentPageIndex() * self::LIMIT;
+			$response = call_user_func($this->loadCallable, $offset);
+
+			$this->pages[$this->getCurrentPageIndex()] = $this->hydrateResponse($response);
+		}
+	}
+
+	/**
+	 * Takes in a raw Webflow response and returns an array of hydrated models.
+	 *
+	 * @param array<string,mixed> $response
+	 * @return array<int,T>
+	 */
+	private function hydrateResponse(array $response): array
+	{
+		$hydratedModels = [];
+
+		foreach ($response[$this->responseDataKey] as $resultData) {
+			/** @var T $hydratedModel */
+			$hydratedModel = $this->model::createFromArray($resultData);
+			$hydratedModels[] = $hydratedModel;
+		}
+
+		return $hydratedModels;
+	}
+
+	private function getCurrentPageIndex(): int
+	{
+		return (int) (max(1, ceil($this->currentItemIndex / self::LIMIT)) - 1);
+	}
+
+	/**
+	 * Webflow uses various keys for the list of results they return in
+	 * paginated endpoints (ex.: `items`, `users`, etc.)
+	 *
+	 * This method guesses that key from a response by removing all
+	 * pagination-related keys and returning the remaining key.
+	 *
+	 * @param array<string,mixed> $firstResponse
+	 */
+	private function guessDataKey(array $firstResponse): string
+	{
+		unset($firstResponse['count']);
+		unset($firstResponse['limit']);
+		unset($firstResponse['offset']);
+		unset($firstResponse['total']);
+
+		return array_keys($firstResponse)[0];
+	}
+}

--- a/tests/real_use_ci_test.php
+++ b/tests/real_use_ci_test.php
@@ -38,6 +38,12 @@ $createdItem = $client->createCollectionItem($testCollection, $newItem, true);
 $createdItem->name .= ' :)';
 $client->updateCollectionItem($testCollection, $createdItem, true);
 
+// Loop over items to test paginated list
+$items = $client->listCollectionItems($testCollection);
+foreach ($items as $item) {
+	// Nothing to do
+}
+
 // Create a duplicate, then delete it
 $deletionTestItem = new CollectionItem(
 	name: 'Deletion Test Item',
@@ -57,7 +63,7 @@ $client->removeCollectionItem($testCollection, $deletionTestItem, false);
 // Membership user tests
 $accessGroups = $client->listAccessGroups();
 $users = $client->listUsers();
-$user = $client->getUser($users[0]->id);
+$user = $client->getUser($users->first()->id);
 $user->setData('country', ($user->data['country'] ?? null) === 'Canada' ? 'Wonderland' : 'Canada');
 $client->updateUser($user);
 

--- a/tests/sample_data.php
+++ b/tests/sample_data.php
@@ -411,7 +411,7 @@ return [
 			'count' => 1,
 			'limit' => 1,
 			'offset' => 0,
-			'total' => 5,
+			'total' => 1,
 		],
 
 		'DELETE' => [
@@ -2409,7 +2409,7 @@ return [
 			'count' => 5,
 			'limit' => 5,
 			'offset' => 0,
-			'total' => 201,
+			'total' => 5,
 		],
 	],
 
@@ -2467,6 +2467,24 @@ return [
 	],
 
 	'/sites/580e63e98c9a982ac9b8b741/accessgroups' => [
+		'GET' => [
+			'accessGroups' => [
+				[
+					'_id' => '62be58d404be8a6cc900c081',
+					'name' => 'Webflowers',
+					'shortId' => 'jo',
+					'slug' => 'webflowers',
+					'createdOn' => '2022-08-01T19:41:48.349Z',
+				],
+			],
+			'count' => 1,
+			'limit' => 10,
+			'offset' => 0,
+			'total' => 1,
+		],
+	],
+
+	'/sites/paginationtest/accessgroups' => [
 		'GET' => [
 			'accessGroups' => [
 				[


### PR DESCRIPTION
This PR adds pagination support to the API Client.

BREAKING CHANGE: Endpoints `listCollectionItems()`, `listUsers()` and `listAccessGroups()` now return a `PaginatedList` instance instead of an array.